### PR TITLE
Idiot proof cache_dir config

### DIFF
--- a/lib/betamocks/response_cache.rb
+++ b/lib/betamocks/response_cache.rb
@@ -13,6 +13,7 @@ module Betamocks
     end
 
     def load_response
+      raise IOError, "Betamocks cache_dir: [#{Betamocks.configuration.cache_dir}], does not exist" unless File.directory?(Betamocks.configuration.cache_dir)
       Faraday::Response.new(load_env) if File.exist?(file_path)
     end
 

--- a/spec/response_cache_spec.rb
+++ b/spec/response_cache_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Betamocks::ResponseCache do
+  let(:env) { double('Faraday::Env') }
+  let(:config) { {method: 'get', path: '/fake', file_path: '/fake/file.yml'} }
+
+  subject { described_class.new(env: env, config: config) }
+
+  context 'with a non-existent cache_dir' do
+    before(:each) do
+      Betamocks.configure do |config|
+        config.enabled = true
+        config.cache_dir = File.join('this', 'does', 'not', 'exist')
+        config.services_config = File.join(Dir.pwd, 'spec', 'support', 'betamocks.yml')
+      end
+    end
+    it '#load_response raises IOError' do
+      expect{subject.load_response}.to raise_error(IOError)
+    end
+  end
+end


### PR DESCRIPTION
I accidentally had a non-existent folder set as my `cache_dir`.  Figured I'd be a good citizen and idiot-proof this since most of us in `vets-api` will be using this soon.