### PR TITLE
Pv match host port

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ end
 #### Services config
 The services config is YAML file containing a list (array) of services.
 Each item in the services list contains:
-- __base_urls__: one or more domains for each environment of the API.
+- __base_uri__: one or more host:port combinations for each environment of the API.
 - __endpoints__: a list of endpoints within the API to be mocked (all others will not be mocked).
 Each endpoint will then describe its method and path.
   - __method__: HTTP method as a symbol :get, :post, :put, etc.

--- a/lib/betamocks/configuration.rb
+++ b/lib/betamocks/configuration.rb
@@ -8,7 +8,7 @@ module Betamocks
     attr_writer :recording, :enabled
 
     def find_endpoint(env)
-      service = service_by_host(env)
+      service = service_by_host_port(env)
       return nil unless service
       service[:endpoints].select { |e| matches_path(e, env.method, env.url.path) }.first
     end
@@ -46,8 +46,8 @@ module Betamocks
       @base_urls ||= config[:services].map { |s| s[:base_urls] }.flatten
     end
 
-    def service_by_host(env)
-      config[:services].select { |s| s[:base_uri] == env.url.host }.first
+    def service_by_host_port(env)
+      config[:services].select { |s| s[:base_uri] == "#{env.url.host}:#{env.url.port}" }.first
     end
 
     def matches_path(endpoint, method, path)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe Betamocks::Configuration do
         end
       end
 
+      context 'with overlapping hosts' do
+        let(:env) { double('Faraday::Env') }
+        let(:url) { URI('http://bnb.data.bl.uk:8080/doc/resource/009407494.json') }
+
+        it 'returns the correct endpoint based on port' do
+          endpoint = Betamocks.configuration.find_endpoint(env)
+          expect(endpoint).to eq(method: :get, path: '/doc/resource/*', file_path: 'bnb/book8080')
+        end
+      end
+
       context 'with an unmocked endpoint' do
         let(:env) { double('Faraday::Env') }
         let(:url) { URI('http://foo.com/bar.json') }

--- a/spec/support/betamocks.yml
+++ b/spec/support/betamocks.yml
@@ -12,14 +12,21 @@
       :body: 'foo'
 
 # book service
-- :base_uri: bnb.data.bl.uk
+- :base_uri: bnb.data.bl.uk:80
   :endpoints:
   - :method: :get
     :path: "/doc/resource/*"
     :file_path: "bnb/book"
 
+# book service alt port
+- :base_uri: bnb.data.bl.uk:8080
+  :endpoints:
+  - :method: :get
+    :path: "/doc/resource/*"
+    :file_path: "bnb/book8080"
+
 # requestb.in
-- :base_uri: requestb.in
+- :base_uri: requestb.in:443
   :endpoints:
   - :method: :post
     :path: "/tithviti"
@@ -41,7 +48,7 @@
       :uid_locator: 'uuid'
 
 # callook.info
-- :base_uri: callook.info
+- :base_uri: callook.info:443
   :endpoints:
   - :method: :get
     :path: "/W1AW/json"


### PR DESCRIPTION
Adds multiplexing on port, useful for vets-api deployed environment where services are configured with identical hosts due to forward proxy.