### PR TITLE
Overlapping Endpoints where Matching Fails

### DIFF
--- a/lib/betamocks/configuration.rb
+++ b/lib/betamocks/configuration.rb
@@ -51,7 +51,7 @@ module Betamocks
     end
 
     def matches_path(endpoint, method, path)
-      /#{endpoint[:path].gsub('/', '\/').gsub('*', '.*')}/ =~ path && endpoint[:method] == method
+      /\A#{endpoint[:path].gsub('/', '\/').gsub('*', '[^\/]*')}\Z/ =~ path && endpoint[:method] == method
     end
   end
 end

--- a/lib/betamocks/configuration.rb
+++ b/lib/betamocks/configuration.rb
@@ -51,7 +51,7 @@ module Betamocks
     end
 
     def matches_path(endpoint, method, path)
-      /\A#{endpoint[:path].gsub('/', '\/').gsub('*', '[^\/]*')}\Z/ =~ path && endpoint[:method] == method
+      /\A#{endpoint[:path].gsub('/', '\/').gsub('*', '[^\/]*')}\z/ =~ path && endpoint[:method] == method
     end
   end
 end

--- a/lib/betamocks/version.rb
+++ b/lib/betamocks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Betamocks
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -46,6 +46,33 @@ RSpec.describe Betamocks::Configuration do
         end
       end
 
+      context 'with overlapping endpoints that contain *' do
+        let(:env) { double('Faraday::Env') }
+        let(:url) { URI('http://bnb.data.bl.uk/doc/resource/blah/009407494.json') }
+
+        it 'returns the correct endpoint' do
+          endpoint = Betamocks.configuration.find_endpoint(env)
+          expect(endpoint).to eq(method: :get, path: '/doc/resource/blah/*', file_path: 'bnb/blah_books')
+        end
+      end
+
+      context 'with overlapping endpoints' do
+        let(:env) { double('Faraday::Env') }
+        let(:url) { URI('http://petpics.com/a/cat') }
+        let(:extended_url) { URI(url.to_s + '/and/dog') }
+
+        it 'returns the non-extended url' do
+          endpoint = Betamocks.configuration.find_endpoint(env)
+          expect(endpoint).to eq(method: :get, path: '/a/cat', file_path: 'cats')
+        end
+
+        it 'returns the non-extended url' do
+          allow(env).to receive(:url).and_return(extended_url)
+          endpoint = Betamocks.configuration.find_endpoint(env)
+          expect(endpoint).to eq(method: :get, path: '/a/cat/and/dog', file_path: 'cats/with/dogs')
+        end
+      end
+
       context 'with an unmocked endpoint' do
         let(:env) { double('Faraday::Env') }
         let(:url) { URI('http://foo.com/bar.json') }

--- a/spec/support/betamocks.yml
+++ b/spec/support/betamocks.yml
@@ -17,6 +17,9 @@
   - :method: :get
     :path: "/doc/resource/*"
     :file_path: "bnb/book"
+  - :method: :get
+    :path: "/doc/resource/blah/*"
+    :file_path: "bnb/blah_books"
 
 # book service alt port
 - :base_uri: bnb.data.bl.uk:8080
@@ -56,3 +59,13 @@
     :cache_multiple_responses:
       :uid_location: url
       :uid_locator: '\/(.+)\/json'
+
+# petpics.com
+- :base_uri: petpics.com:80
+  :endpoints:
+  - :method: :get
+    :path: "/a/cat"
+    :file_path: "cats"
+  - :method: :get
+    :path: "/a/cat/and/dog"
+    :file_path: "cats/with/dogs"


### PR DESCRIPTION
Added two specs that illustrate what is happening with `letters` right now.  I'm not sure how to solve, so the specs currently fail:

```
Failures:

  1) Betamocks::Configuration with a basic setting #find_endpoint? with overlapping endpoints that contain * returns the correct endpoint
     Failure/Error: expect(endpoint).to eq(method: :get, path: '/doc/resource/blah/*', file_path: 'bnb/blah_books')
     
       expected: {:method=>:get, :path=>"/doc/resource/blah/*", :file_path=>"bnb/blah_books"}
            got: {:method=>:get, :path=>"/doc/resource/*", :file_path=>"bnb/book"}
     
       (compared using ==)
     
       Diff:
       
       @@ -1,4 +1,4 @@
       -:file_path => "bnb/blah_books",
       +:file_path => "bnb/book",
        :method => :get,
       -:path => "/doc/resource/blah/*",
       +:path => "/doc/resource/*",
       
     # ./spec/configuration_spec.rb:55:in `block (5 levels) in <top (required)>'

  2) Betamocks::Configuration with a basic setting #find_endpoint? with overlapping endpoints returns the non-extended url
     Failure/Error: expect(endpoint).to eq(method: :get, path: '/a/cat/and/dog', file_path: 'cats/with/dogs')
     
       expected: {:method=>:get, :path=>"/a/cat/and/dog", :file_path=>"cats/with/dogs"}
            got: {:method=>:get, :path=>"/a/cat", :file_path=>"cats"}
     
       (compared using ==)
     
       Diff:
       
       @@ -1,4 +1,4 @@
       -:file_path => "cats/with/dogs",
       +:file_path => "cats",
        :method => :get,
       -:path => "/a/cat/and/dog",
       +:path => "/a/cat",
       
     # ./spec/configuration_spec.rb:72:in `block (5 levels) in <top (required)>'
```