### PR TITLE
Support multiple request body id captures

### DIFF
--- a/lib/betamocks/response_cache.rb
+++ b/lib/betamocks/response_cache.rb
@@ -18,6 +18,7 @@ module Betamocks
         Faraday::Response.new(load_env(@generated_file_name))
       else
         Betamocks.logger.warn "Mock response not found: [#{file_path(@generated_file_name)}]"
+        nil
       end
     end
 

--- a/lib/betamocks/uid.rb
+++ b/lib/betamocks/uid.rb
@@ -22,7 +22,7 @@ module Betamocks
       locator = uid_config[:uid_locator]
       case location
       when :body
-        @env.body[/#{locator}/, 1]
+        @env.body.match(/#{locator}/).to_a[1..-1]&.join('_')
       when :header
         @env.request_headers[locator]
       when :query

--- a/lib/betamocks/version.rb
+++ b/lib/betamocks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Betamocks
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end

--- a/lib/betamocks/version.rb
+++ b/lib/betamocks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Betamocks
-  VERSION = '0.5.3'
+  VERSION = '0.6.0'
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -100,6 +100,38 @@ RSpec.describe Betamocks::Middleware do
           end
         end
 
+        context 'with a request that includes multiple identifiers in the request body' do
+          let(:xml) do
+            '<soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:v1="http://viers.va.gov/cdi/CDI/commonService/v1" xmlns:v12="http://viers.va.gov/cdi/eMIS/RequestResponse/v1" xmlns:v13="http://viers.va.gov/cdi/eMIS/commonService/v1" xmlns:v11="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v1">
+          <soap:Header>
+            <v1:inputHeaderInfo>
+              <v1:userId>vets.gov</v1:userId>
+              <v1:sourceSystemName>vets.gov</v1:sourceSystemName>
+              <v1:transactionId>245e2072-c7a6-48f0-a429-549355af5cf9</v1:transactionId>
+            </v1:inputHeaderInfo>
+          </soap:Header>
+          <soap:Body>
+            <v11:eMISserviceEpisodeRequest>
+              <v12:edipiORicn>
+                <v13:edipiORicnValue>1607472595</v13:edipiORicnValue>
+                <v13:inputType>EDIPI</v13:inputType>
+              </v12:edipiORicn>
+            </v11:eMISserviceEpisodeRequest>
+          </soap:Body>
+        </soap:Envelope>'
+          end
+          let(:cache_path) do
+            File.join('spec', 'support', 'cache', 'multi', 'body', 'captures', 'EpisodeRequest_1607472595.yml')
+          end
+
+          it 'has the expected file name' do
+            VCR.use_cassette('request_bin_post_multiple') do
+              conn.post '/tithvitj', xml
+              expect(File).to exist(File.join(Dir.pwd, cache_path))
+            end
+          end
+        end
+
         context 'with a request that includes the identifier in the request headers' do
           let(:cache_path) do
             File.join('spec', 'support', 'cache', 'multi', 'header', '1607472595.yml')

--- a/spec/support/betamocks.yml
+++ b/spec/support/betamocks.yml
@@ -37,6 +37,12 @@
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'root="2.16.840.1.113883.4.1" extension="(\d{9})"'
+  - :method: :post
+    :path: "/tithvitj"
+    :file_path: "multi/body/captures"
+    :cache_multiple_responses:
+      :uid_location: body
+      :uid_locator: '<v11:eMISservice(EpisodeRequest)>\n\s+<v12:edipiORicn>\n\s+<v13:edipiORicnValue>(\d+)'
   - :method: :get
     :path: "/1gv9b4e1"
     :file_path: "multi/header"

--- a/spec/support/vcr_cassettes/request_bin_post_multiple.yml
+++ b/spec/support/vcr_cassettes/request_bin_post_multiple.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://requestb.in/tithvitj
+    body:
+      encoding: UTF-8
+      string: |-
+        <env:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+                   <env:Body>
+                     <id extension="WSDOC1610281012015841158653421" root="2.16.840.1.113883.4.349"/>
+                     <creationTime value="20170823174724"/>
+                     <versionCode code="3.0"/>
+                   </env:Body>
+                 </env:Envelope>
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Wed, 23 Aug 2017 17:46:57 GMT
+      content-type:
+      - text/html; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      set-cookie:
+      - __cfduid=d32f6c31f7ac2a6b5ceebf0f5dddbce361503510417; expires=Thu, 23-Aug-18
+        17:46:57 GMT; path=/; domain=.requestb.in; HttpOnly
+      sponsored-by:
+      - https://www.runscope.com
+      via:
+      - 1.1 vegur
+      strict-transport-security:
+      - max-age=15552000
+      x-content-type-options:
+      - nosniff
+      server:
+      - cloudflare-nginx
+      cf-ray:
+      - 392fe4eb390577e4-LAX
+    body:
+      encoding: ASCII-8BIT
+      string: ok
+    http_version: 
+  recorded_at: Wed, 23 Aug 2017 17:47:25 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Adds support for capturing multiple ids from a request body to generate a cache file name e.g.
```xml
<v11:eMISserviceEpisodeRequest>
  <v12:edipiORicn>
  <v13:edipiORicnValue>1607472595</v13:edipiORicnValue>
```
with a config uid_locator regex `<v11:eMISservice(EpisodeRequest)>\n\s+<v12:edipiORicn>\n\s+<v13:edipiORicnValue>(\d+)` generates a file named `EpisodeRequest_1607472595.yml`
