### PR TITLE
Update Faraday client to latest minor version

### DIFF
--- a/betamocks.gemspec
+++ b/betamocks.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'climate_control'
   spec.add_development_dependency 'rack'
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '<= 0.12.2']
+  spec.add_dependency 'faraday', ['>= 0.7.4', '<= 0.17.0']
   spec.add_dependency 'activesupport', ['>= 4.2', '<= 6.0']
   spec.add_dependency 'adler32'
 end

--- a/lib/betamocks/version.rb
+++ b/lib/betamocks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Betamocks
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end


### PR DESCRIPTION
## Background

As part of an effort to reduce technical debt and improve the resiliency of `vets-api`, we would like to upgrade the `faraday` gem to the latest version. 

This repository is a direct dependency of `vets-api` and thus requires upgrading prior to upgrading `vets-api` itself.

See [#2369](https://github.com/department-of-veterans-affairs/va.gov-team/issues/2369) for more information.