### PR TITLE
update faraday dependency

### DIFF
--- a/betamocks.gemspec
+++ b/betamocks.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'climate_control'
   spec.add_development_dependency 'rack'
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '<= 0.17.0']
+  spec.add_dependency 'faraday', ['>= 0.7.4', '< 0.18']
   spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'adler32'
 end


### PR DESCRIPTION
As part of an effort to reduce technical debt within vets-api, this allows for newer versions of faraday

This repository is a direct dependency of vets-api and thus requires upgrading prior to upgrading vets-api itself. 

Specifically the [googleauth gem ](https://github.com/googleapis/google-auth-library-ruby/blob/master/googleauth.gemspec#L31) has a runtime dependency of "faraday", ">= 0.17.3", "< 2.0" 

 - [x] rerun tests with newer versions of faraday