### PR TITLE
[23803] Adding ability to define an additional non-id field to determine which mocked data to serve

### DIFF
--- a/lib/betamocks/configuration.rb
+++ b/lib/betamocks/configuration.rb
@@ -72,9 +72,11 @@ module Betamocks
       location = endpoint_config[:uid_location].to_sym
       locator = endpoint_config[:uid_locator]
 
+      optional_locator = endpoint_config[:optional_code_locator]
+
       case location
       when :body
-        /#{locator}/ =~ env.body
+        /#{locator}/ =~ env.body && /#{optional_locator}/ =~ env.body
       when :header
         return false # TODO
       when :query

--- a/lib/betamocks/optional_locator.rb
+++ b/lib/betamocks/optional_locator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rack'
+
+module Betamocks
+  class OptionalLocator
+    attr_writer :env, :endpoint_config
+
+    def initialize(env)
+      @env = env
+      @endpoint_config = Betamocks.configuration.find_endpoint(@env)
+    end
+
+    def generate
+      matched_optional_locator = generate_optional_locator_dir(@endpoint_config[:cache_multiple_responses])
+      return '' unless matched_optional_locator
+
+      matched_optional_locator.gsub(/[^0-9a-z]/i, '')
+    end
+
+    private
+
+    def generate_optional_locator_dir(locator_config)
+      return unless locator_config
+      # Optional Locator must exist in the same location as the UID
+      location = locator_config[:uid_location].to_sym
+      locator = locator_config[:optional_code_locator]
+      # Currently only works if optional locator is found in the body
+      return '' unless location == :body && locator
+
+      @env.body[/#{locator}/, 1]
+    end
+  end
+end

--- a/lib/betamocks/optional_locator.rb
+++ b/lib/betamocks/optional_locator.rb
@@ -20,14 +20,10 @@ module Betamocks
     private
 
     def generate_optional_locator_dir(locator_config)
-      return unless locator_config
-      # Optional Locator must exist in the same location as the UID
-      location = locator_config[:uid_location].to_sym
-      locator = locator_config[:optional_code_locator]
-      # Currently only works if optional locator is found in the body
-      return '' unless location == :body && locator
+      # Currently only works if optional locator is found in the body (must be same as the uid location)
+      return unless locator_config && locator_config[:uid_location].to_sym == :body
 
-      @env.body[/#{locator}/, 1]
+      @env.body[/#{locator_config[:optional_code_locator]}/, 1]
     end
   end
 end

--- a/lib/betamocks/response_cache.rb
+++ b/lib/betamocks/response_cache.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'uid'
+require_relative 'optional_locator'
 
 module Betamocks
   class ResponseCache
@@ -14,8 +15,10 @@ module Betamocks
 
     def load_response
       raise IOError, "Betamocks cache_dir: [#{Betamocks.configuration.cache_dir}], does not exist" unless File.directory?(Betamocks.configuration.cache_dir)
-      if File.exist?(file_path(@generated_file_name))
-        Faraday::Response.new(load_env(@generated_file_name))
+      if File.exist?(optional_locator_file_path(@generated_file_name))
+        Faraday::Response.new(load_env(optional_locator_file_path(@generated_file_name)))
+      elsif File.exist?(file_path(@generated_file_name))
+        Faraday::Response.new(load_env(file_path(@generated_file_name)))
       else
         Betamocks.logger.warn "Mock response not found: [#{file_path(@generated_file_name)}]"
         nil
@@ -24,7 +27,7 @@ module Betamocks
 
     def default_response
       raise IOError, "Betamocks default response requested but none exist. Please create one at: [#{file_path('default.yml')}]." unless File.exist?(file_path('default.yml'))
-      Faraday::Response.new(load_env('default.yml'))
+      Faraday::Response.new(load_env(file_path('default.yml')))
     end
 
     def save_response(env)
@@ -40,8 +43,8 @@ module Betamocks
 
     private
 
-    def load_env(file_name)
-      cached_env = YAML.load_file(file_path(file_name))
+    def load_env(file)
+      cached_env = YAML.load_file(file)
       @env.method = cached_env[:method]
       @env.body = cached_env[:body]
       @env.response_headers = cached_env[:headers]
@@ -62,6 +65,10 @@ module Betamocks
 
     def file_path(file_name = nil)
       File.join(dir_path, file_name || @generated_file_name)
+    end
+
+    def optional_locator_file_path(file_name = nil)
+      File.join(dir_path, OptionalLocator.new(@env).generate, file_name || @generated_file_name)
     end
 
     def generate_file_name

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -93,6 +93,30 @@ RSpec.describe Betamocks::Configuration do
           endpoint = Betamocks.configuration.find_endpoint(env)
           expect(endpoint).to include(method: :post, path: '/get_animals', file_path: '/pics/lions')
         end
+
+        context 'and optional_code_locator is defined by service' do
+          let(:url) { URI('http://animal.pics/get_animals') }
+          let(:optional_code_locator_value) { '<Quality>"HI-DEF"</Quality>' }
+
+          before do
+            allow(env).to receive(:method).and_return(:post)
+            allow(env).to receive(:body)
+            .and_return("#{optional_code_locator_value}<AnimalType>Gorilla</AnimalType><Id>12345678</Id>")
+          end
+
+          it 'returns the proper endpoint for request body' do
+            endpoint = Betamocks.configuration.find_endpoint(env)
+            expect(endpoint).to include(method: :post, path: '/get_animals', file_path: '/pics/gorillas')
+          end
+
+          context 'and optional_code_locator does not match mocked value' do
+           let(:optional_code_locator_value) { '<Quality>ULTRA-CRISP-DEF</Quality>' }
+
+            it 'responds with an argument error' do
+              expect { Betamocks.configuration.find_endpoint(env) }.to raise_exception(ArgumentError)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/optional_locator_spec.rb
+++ b/spec/optional_locator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Betamocks::OptionalLocator do
+  let(:env) { double('Faraday::Env') }
+  let(:method) { :post }
+  let(:url) { URI('http://animal.pics/get_animals') }
+  let(:optional_code_locator_value) { '<Quality>"HI-DEF"</Quality>' }
+  let(:expected_optional_code_locator) { 'HIDEF' }
+
+  before(:each) do
+    Betamocks.configure do |config|
+      config.enabled = true
+      config.cache_dir = File.join(Dir.pwd, 'spec', 'support', 'cache')
+      config.services_config = File.join(Dir.pwd, 'spec', 'support', 'betamocks.yml')
+    end
+    allow(env).to receive(:url).and_return(url)
+    allow(env).to receive(:method).and_return(method)
+    allow(env).to receive(:body)
+    .and_return("<Animal>#{optional_code_locator_value}<AnimalType>Gorilla</AnimalType><Id>12345678</Id></Animal>")
+  end
+
+  describe '#generate' do
+    subject { described_class.new(env).generate }
+
+    context 'when cache_multiple_responses is defined in the endpoint configuration' do
+      context 'when optional_code_locator is not defined in the end point configuration' do
+        let(:url) { URI('http://requestb.in:443/tithviti') }
+
+        it 'returns an empty string' do
+          expect(subject).to eq('')
+        end
+      end
+
+      context 'when optional_code_locator is defined in the end point configuration' do
+        context 'when uid_location is set to an arbitrary value' do
+          let(:url) { URI('http://garbage.day/get_garbage') }
+          let(:method) { :get }
+
+          it 'returns an empty string' do
+            expect(subject).to eq('')
+          end
+        end
+
+        context 'when uid_location is set to :body' do
+          let(:url) { URI('http://animal.pics/get_animals') }
+
+          it 'returns the expected optional code locator' do
+            expect(subject).to eq(expected_optional_code_locator)
+          end
+        end
+      end
+    end
+
+    context 'when cache_multiple_responses is not defined in the endpoint configuration' do
+      let(:url) { URI('http://petpics.com/a/cat') }
+      let(:method) { :get }
+
+      it 'returns an empty string' do
+        expect(subject).to eq('')
+      end
+    end
+  end
+end

--- a/spec/support/betamocks.yml
+++ b/spec/support/betamocks.yml
@@ -85,3 +85,21 @@
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: '<AnimalType>Lion<\/AnimalType><Id>(\d{8})'
+  - :method: :post
+    :path: "/get_animals"
+    :file_path: "/pics/gorillas"
+    :cache_multiple_responses:
+      :uid_location: body
+      :uid_locator: '<AnimalType>Gorilla<\/AnimalType><Id>(\d{8})'
+      :optional_code_locator: '<Quality>"(HI-DEF|LO-DEF)"</Quality>'
+
+# garbage.day
+- :base_uri: garbage.day:80
+  :endpoints:
+  - :method: :get
+    :path: "/get_garbage"
+    :file_path: "pics/garbage"
+    :cache_multiple_responses:
+      :uid_location: some-location
+      :uid_locator: some-locator
+      :optional_code_locator: '<Quality>"(HI-DEF|LO-DEF)"</Quality>'


### PR DESCRIPTION
We are going to start calling the MPI Service with modify code set to either `MVI.COMP1.RMS` or `MVI.COMP2`, the former which calls MPI with requested relationship data, and the latter which calls MPI with requested historical ICN data. In order to do this, we need mocks that look for this modifyCode, in addition to the ICN or profile parameters that it currently looks at. 

This change adds a capability to include an `optional_code_locator` field to the mocks. If it is not defined in the Betamocks `services_config.yml`, for the specific route, this will be ignored. Otherwise, the saved mock will be compared to this regex and can only match the request if it matches both the `uid_locator` and `optional_code_locator`