### PR TITLE
[23803] Bumping version number for optional code locator change

### DIFF
--- a/lib/betamocks/version.rb
+++ b/lib/betamocks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Betamocks
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end


### PR DESCRIPTION
Forgot to bump the version number after the gem change