### PR TITLE
relax faraday dependency to allow < 2.0

### DIFF
--- a/betamocks.gemspec
+++ b/betamocks.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'climate_control'
   spec.add_development_dependency 'rack'
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '< 0.18']
+  spec.add_dependency 'faraday', ['>= 0.7.4', '< 2.0']
   spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'adler32'
 end

--- a/lib/betamocks/version.rb
+++ b/lib/betamocks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Betamocks
-  VERSION = '0.7.1'
+  VERSION = '0.8.0'
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -204,8 +204,8 @@ RSpec.describe Betamocks::Middleware do
           end
         end
 
-        it 'raises a Faraday::ClientError' do
-          expect { conn.get '/v0/users/42/forms' }.to raise_error Faraday::ClientError
+        it 'raises a Faraday::ConnectionFailed' do
+          expect { conn.get '/v0/users/42/forms' }.to raise_error Faraday::ConnectionFailed
         end
       end
 


### PR DESCRIPTION
Relax faraday dependency in order to upgrade faraday on vets-api

https://github.com/department-of-veterans-affairs/va.gov-team/issues/24619