### PR TITLE
Add ability to delay sending the response based on a configured value

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Each endpoint will then describe its method and path.
   - __path__: the path or URL fragment for the endpoint e.g. `/v0/users`.
   Wildcards are allowed for varying parameters within a URL e.g. `/v0/users/*/forms`
   will record both `/v0/users/42/forms` and `/v0/users/101/forms`.
+  - __response_delay__: (optional) delay in seconds in sending the response (useful to simulate real world delays)
 
 ```yaml
 :services:
@@ -60,6 +61,7 @@ Each endpoint will then describe its method and path.
   :endpoints:
   - :method: :get
     :path: "/v0/users/*/forms"
+    :response_delay: 2
 - :base_urls:
   - bnb.data.bl.uk
   :endpoints:

--- a/lib/betamocks/middleware.rb
+++ b/lib/betamocks/middleware.rb
@@ -12,6 +12,10 @@ module Betamocks
       return super unless Betamocks.configuration.enabled?
       @endpoint_config = Betamocks.configuration.find_endpoint(env)
       if @endpoint_config
+        if @endpoint_config[:response_delay] && !Betamocks.configuration.recording?
+          Betamocks.logger.info "sleeping for #{@endpoint_config[:response_delay]} seconds to simulate response delay"
+          sleep @endpoint_config[:response_delay]
+        end
         raise_error(env, @endpoint_config) if @endpoint_config[:error]
         @response_cache = Betamocks::ResponseCache.new(env: env, config: @endpoint_config)
         response = @response_cache.load_response

--- a/lib/betamocks/version.rb
+++ b/lib/betamocks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Betamocks
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end

--- a/spec/support/betamocks.yml
+++ b/spec/support/betamocks.yml
@@ -11,6 +11,14 @@
       :status: 400
       :body: 'foo'
 
+# service with response delay
+- :base_uri: service.with.response.delay:80
+  :endpoints:
+    - :method: :get
+      :path: "/token"
+      :file_path: "default"
+      :response_delay: 2
+
 # book service
 - :base_uri: bnb.data.bl.uk:80
   :endpoints:

--- a/spec/support/vcr_cassettes/token.yml
+++ b/spec/support/vcr_cassettes/token.yml
@@ -1,0 +1,24 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: http://service.with.response.delay/token
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Server:
+          - Server
+        Date:
+          - Mon, 29 Jun 2020 15:46:52 GMT
+        Content-Type:
+          - application/json
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+            "token": "jwt-123-abc"
+          }
+    recorded_at: Thu, 19 Nov 2020 16:45:03 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
This change allows each endpoint to optionally be configured with a `response_delay` which will delay sending the mocked response back by the specified number of seconds. This is helpful to simulate real world delays when calling downstream services (esp. during load testing).

Fixes #27 