### PR TITLE
Add functionality to use paths that contains special parentheses characters 

### DIFF
--- a/lib/betamocks/configuration.rb
+++ b/lib/betamocks/configuration.rb
@@ -62,7 +62,7 @@ module Betamocks
     end
 
     def matches_path(endpoint, method, path)
-      /\A#{endpoint[:path].gsub('/', '\/').gsub('*', '[^\/]*')}\z/ =~ path && endpoint[:method] == method
+      /\A#{endpoint[:path].gsub('/', '\/').gsub('*', '[^\/]*').tr('()', '')}\z/ =~ path && endpoint[:method] == method
     end
 
     def matches_request_params(endpoint, env)

--- a/lib/betamocks/configuration.rb
+++ b/lib/betamocks/configuration.rb
@@ -62,7 +62,8 @@ module Betamocks
     end
 
     def matches_path(endpoint, method, path)
-      /\A#{endpoint[:path].gsub('/', '\/').gsub('*', '[^\/]*').tr('()', '')}\z/ =~ path && endpoint[:method] == method
+      endpoint_path = endpoint[:path].gsub('/', '\/').gsub('(', '\(').gsub(')', '\)').gsub('*', '[^\/]*')
+      /\A#{endpoint_path}\z/ =~ path && endpoint[:method] == method
     end
 
     def matches_request_params(endpoint, env)

--- a/lib/betamocks/configuration.rb
+++ b/lib/betamocks/configuration.rb
@@ -62,8 +62,15 @@ module Betamocks
     end
 
     def matches_path(endpoint, method, path)
-      endpoint_path = endpoint[:path].gsub('/', '\/').gsub('(', '\(').gsub(')', '\)').gsub('*', '[^\/]*')
-      /\A#{endpoint_path}\z/ =~ path && endpoint[:method] == method
+      replacement_map = {
+        '/' => '\/',
+        '(' => '\(',
+        ')' => '\)',
+        '*' => '[^\/]*'
+      }
+      replacement_map.each_pair { |original, replacement| endpoint[:path].gsub!(original, replacement) }
+
+      /\A#{endpoint[:path]}\z/ =~ path && endpoint[:method] == method
     end
 
     def matches_request_params(endpoint, env)

--- a/lib/betamocks/version.rb
+++ b/lib/betamocks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Betamocks
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -121,11 +121,11 @@ RSpec.describe Betamocks::Configuration do
 
       context 'with regex special characters' do
         let(:env) { double('Faraday::Env') }
-        let(:url) { URI("http://animal.pics/get_animals(class='reptilia',pagination=true)" }
+        let(:url) { URI("http://animal.pics/get_animals(class='reptilia',pagination=true)") }
 
-        it 'returns the non-extended url' do
+        it 'returns the special character URL' do
           endpoint = Betamocks.configuration.find_endpoint(env)
-          expect(endpoint).to eq(method: :get, path: "/get_animals(class='reptilia',pagination=true)", file_path: 'pics/reptiles')
+          expect(endpoint).to eq(method: :get, path: "/get_animals(class='reptilia',pagination=true)", file_path: '/pics/reptiles')
         end
       end 
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -118,6 +118,16 @@ RSpec.describe Betamocks::Configuration do
           end
         end
       end
+
+      context 'with overlapping endpoints' do
+        let(:env) { double('Faraday::Env') }
+        let(:url) { URI("http://animal.pics/get_animals(class='reptilia',pagination=true)" }
+
+        it 'returns the non-extended url' do
+          endpoint = Betamocks.configuration.find_endpoint(env)
+          expect(endpoint).to eq(method: :get, path: "/get_animals(class='reptilia',pagination=true)", file_path: 'pics/reptiles')
+        end
+      end 
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Betamocks::Configuration do
         end
       end
 
-      context 'with overlapping endpoints' do
+      context 'with regex special characters' do
         let(:env) { double('Faraday::Env') }
         let(:url) { URI("http://animal.pics/get_animals(class='reptilia',pagination=true)" }
 

--- a/spec/support/betamocks.yml
+++ b/spec/support/betamocks.yml
@@ -100,6 +100,9 @@
       :uid_location: body
       :uid_locator: '<AnimalType>Gorilla<\/AnimalType><Id>(\d{8})'
       :optional_code_locator: '<Quality>"(HI-DEF|LO-DEF)"</Quality>'
+  - :method: :get
+    :path: "/get_animals(class='reptilia',pagination=true)"
+    :file_path: "/pics/reptiles"
 
 # garbage.day
 - :base_uri: garbage.day:80


### PR DESCRIPTION
## Description of change
SharePoint paths have specific use case that uses parentheses to connect to their API. Adding ability to escape these in the `Configuration#matches_path` method.

Also added some expand-ability to avoid the chaining gsubs.

## Original issue(s)
[department-of-veterans-affairs/vets-api#11004](https://github.com/department-of-veterans-affairs/vets-api/pull/11004)
