### PR TITLE
Add support for arbitrary regex in endpoint paths

### DIFF
--- a/spec/support/betamocks.yml
+++ b/spec/support/betamocks.yml
@@ -114,3 +114,37 @@
       :uid_location: some-location
       :uid_locator: some-locator
       :optional_code_locator: '<Quality>"(HI-DEF|LO-DEF)"</Quality>'
+
+# Electronic File Service
+- :name: 'EFS'
+  :base_uri: test.gov:80
+  :endpoints:
+  # Files
+  - :method: :get
+    :path: "/files"
+    :file_path: "efs/files/list"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'id'
+  - :method: :get
+    :path: "/files/recipient"
+    :file_path: "efs/files/recipient"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'id'
+  - :method: :get
+    :path: "/files/{{noRecip}}"
+    :regex_groups:
+      :noRecip: "(?!*(recipient))*"
+    :file_path: "efs/files/download_pdf"
+    :cache_multiple_responses:
+      :uid_location: "url"
+      :uid_locator: "\/files/v1\/(.+)"
+  - :method: :post
+    :path: "/files/{{noRecip}}/generate"
+    :regex_groups:
+      :noRecip: "(?!*(recipient))*"
+    :file_path: "efs/files/download_pdf"
+    :cache_multiple_responses:
+      :uid_location: "url"
+      :uid_locator: "\/files/v1\/(.+)\/generate"


### PR DESCRIPTION
[A previous commit removed support for arbitrary regex in endpoint paths](https://github.com/department-of-veterans-affairs/betamocks/issues/30). I see why the change was made - to support literal characters such as `(` and `)` in the endpoint paths. However, that commit took away the ability to add arbitrary regex in endpoint paths, which breaks being able to uniquely match certain endpoints. 

This is one approach the gem could take - an opt-in configuration where regex is named and provided as a list. This has various pros/cons listed below. Here is an example:

```yaml
- :method: :get
  :path: "/files/{{noRecip}}"
  :regex_groups:
    # match anything but the word "recipient"
    :noRecip: "(?!*(recipient))*"
    :file_path: "efs/files/download_pdf"
  :cache_multiple_responses:
    :uid_location: "url"
    :uid_locator: "\/files/v1\/(.+)"
```

Pros of this approach:
- support arbitrary regex
- makes endpoint paths more readable
- additive-only, no endpoint reconfig needed

Cons of this approach:
- a little complex just to support the original intent of the gem AND support literal characters that need to be escaped