### PR TITLE
Update load_env to use response_body

### DIFF
--- a/betamocks.gemspec
+++ b/betamocks.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'climate_control'
   spec.add_development_dependency 'rack'
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '< 2.0']
+  spec.add_dependency 'faraday', ['>= 1', '< 2.0']
   spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'adler32'
 end

--- a/lib/betamocks/response_cache.rb
+++ b/lib/betamocks/response_cache.rb
@@ -33,7 +33,7 @@ module Betamocks
     def save_response(env)
       response = {
         method: env.method,
-        body: env.body,
+        body: env.response_body,
         headers: env.response_headers.as_json,
         status: env.status
       }
@@ -46,7 +46,7 @@ module Betamocks
     def load_env(file)
       cached_env = YAML.load_file(file)
       env.method = cached_env[:method]
-      env.body = cached_env[:body]
+      env.response_body = cached_env[:body]
       env.response_headers = cached_env[:headers]
       env.status = cached_env[:status]
       env


### PR DESCRIPTION
Update `load_env` to use `response_body`. 

```
If you have written a custom adapter, please be aware that env.body is now an alias to the two new properties request_body and response_body
```

In the vets-api faraday update, all instances of `body` were changed to `response_body`

## Testing

- In your `Gemfile` change betamocks to point to this branch
   ```ruby
    gem 'betamocks', git: 'https://github.com/department-of-veterans-affairs/betamocks', branch: 'update-faraday'
    ``` 
- `bundle install`
- Sign-in with `oauth=true`
